### PR TITLE
remove deprecated deepseek model names

### DIFF
--- a/src/main/services/deepseek.js
+++ b/src/main/services/deepseek.js
@@ -4,7 +4,7 @@
  */
 
 const DEEPSEEK_API_BASE = 'https://api.deepseek.com'
-const DEFAULT_MODEL = 'deepseek-chat' // 或 'deepseek-reasoner' 用于推理任务
+const DEFAULT_MODEL = 'deepseek-v4-pro' // 或 'deepseek-v4-flash' 省钱
 
 class DeepSeekService {
   constructor() {


### PR DESCRIPTION
As UTC+8 2026.7.24 23:59 deepseek removed the support of previous model names, new DeepSeek-V4-Pro model should be used to replace it. 